### PR TITLE
fix  for ordering of images and folders in alphabetical order in Media Bar when uploaded manually

### DIFF
--- a/dmAdminPlugin/modules/dmMediaLibrary/templates/pathSuccess.php
+++ b/dmAdminPlugin/modules/dmMediaLibrary/templates/pathSuccess.php
@@ -32,7 +32,14 @@ else
 
 if ($children = $folder->getNode()->getChildren())
 {
-  foreach($children as $f)
+  $arrChildren = array();
+  foreach($children as $f) {
+    $arrChildren[$f->getName()] = $f;
+  }
+
+  ksort($arrChildren);
+
+  foreach($arrChildren as $f)
   {
     echo _tag('li.folder',
       _link($sf_context->getRouting()->getMediaUrl($f))->text(

--- a/dmCorePlugin/modules/dmInterface/templates/_mediaBarInner.php
+++ b/dmCorePlugin/modules/dmInterface/templates/_mediaBarInner.php
@@ -27,7 +27,14 @@ else
 
 if ($folders = $folder->getNode()->getChildren())
 {
-  foreach($folders as $f)
+  $arrFolders = array();
+  foreach($folders as $f) {
+    $arrFolders[$f->getName()] = $f;
+  }
+
+  ksort($arrFolders);
+
+  foreach($arrFolders as $f)
   {
     echo _tag("li.folder#dmf".$f->get('id'),
       ($f->isWritable() ? _media('dmCore/images/media/folder.png')->size(64, 64)


### PR DESCRIPTION
Note: _all_ images & folders get ordered in alphabetical order even the existing ones in the database.
- resolve issue: 'Images & Folders displayed unordered in Media Bar (front & admin) when uploaded manually'
- for details see: http://community.diem-project.org/issues/33
