### PR TITLE
Many-to-Many defaults in Forms

### DIFF
--- a/dmCorePlugin/data/generator/dmDoctrineForm/default/template/sfDoctrineFormGeneratedInheritanceTemplate.php
+++ b/dmCorePlugin/data/generator/dmDoctrineForm/default/template/sfDoctrineFormGeneratedInheritanceTemplate.php
@@ -115,7 +115,7 @@ abstract class Base<?php echo $this->modelName ?>Form extends <?php echo $this->
 <?php foreach ($this->getManyToManyRelations() as $relation): ?>
     if (isset($this->widgetSchema['<?php echo $this->underscore($relation['alias']) ?>_list']))
     {
-      $this->setDefault('<?php echo $this->underscore($relation['alias']) ?>_list', $this->object-><?php echo $relation['alias']; ?>->getPrimaryKeys());
+      $this->setDefault('<?php echo $this->underscore($relation['alias']) ?>_list', array_merge((array)$this->getDefault('<?php echo $this->underscore($relation['alias']) ?>_list'),$this->object-><?php echo $relation['alias']; ?>->getPrimaryKeys()));
     }
 
 <?php endforeach; ?>

--- a/dmCorePlugin/data/generator/dmDoctrineForm/default/template/sfDoctrineFormGeneratedTemplate.php
+++ b/dmCorePlugin/data/generator/dmDoctrineForm/default/template/sfDoctrineFormGeneratedTemplate.php
@@ -157,7 +157,7 @@ abstract class Base<?php echo $this->modelName ?>Form extends <?php echo $this->
 <?php foreach ($manyRelations as $relation): ?>
     if (isset($this->widgetSchema['<?php echo $this->underscore($relation['alias']) ?>_list']))
     {
-      $this->setDefault('<?php echo $this->underscore($relation['alias']) ?>_list', $this->object-><?php echo $relation['alias']; ?>->getPrimaryKeys());
+        $this->setDefault('<?php echo $this->underscore($relation['alias']) ?>_list', array_merge((array)$this->getDefault('<?php echo $this->underscore($relation['alias']) ?>_list'),$this->object-><?php echo $relation['alias']; ?>->getPrimaryKeys()));
     }
 
 <?php endforeach; ?>


### PR DESCRIPTION
Fixes a bug for Diem `*_list` form field which also enables passing `defaults[*_list][]...` parameter
