### PR TITLE
HTTPS support for DmPage: redirect to/from HTTPS if is_ssl is true/false

### DIFF
--- a/dmAdminPlugin/modules/dmPage/lib/dmAdminPageMetaView.php
+++ b/dmAdminPlugin/modules/dmPage/lib/dmAdminPageMetaView.php
@@ -16,7 +16,8 @@ class dmAdminPageMetaView
     'keywords' => 'Keywords',
     'is_active' => 'Available',
     'is_secure' => 'Secure',
-    'is_indexable' => 'Indexable'
+    'is_indexable' => 'Indexable',
+    'is_ssl' => 'HTTPS'
   );
 
   public function __construct(dmHelper $helper, dmI18n $i18n)

--- a/dmCorePlugin/config/doctrine/schema.yml
+++ b/dmCorePlugin/config/doctrine/schema.yml
@@ -4,7 +4,7 @@ DmPage:
   actAs:
     NestedSet:
     I18n:
-      fields:               [slug, name, title, h1, description, keywords, auto_mod, is_active, is_secure, is_indexable]
+      fields:               [slug, name, title, h1, description, keywords, auto_mod, is_active, is_secure, is_indexable, is_ssl]
       length:               7
   columns:
     module:                 { type: string(127), notnull: true }
@@ -21,6 +21,7 @@ DmPage:
     is_secure:              { type: boolean, notnull: true, default: false } # requires authentication
     credentials:            { type: string(255), notnull: false }
     is_indexable:           { type: boolean, notnull: true, default: true }
+    is_ssl:                 { type: boolean, notnull: true, default: false }
   indexes:
     recordModuleAction:
       fields:               [ module, action, record_id ]

--- a/dmCorePlugin/data/dm/i18n/en_de.yml
+++ b/dmCorePlugin/data/dm/i18n/en_de.yml
@@ -198,6 +198,7 @@
 "Available": "Vorhanden"
 "Requires authentication": "Erfordert Authentifizierung"
 "Search engine crawlers": "Suchmaschinenroboter"
+"Use HTTPS": "HTTPS verwenden"
 "Show page structure": "Seitenstruktur anzeigen"
 "Generate sitemap": "Sitemap generieren"
 "Links": "Links"

--- a/dmCorePlugin/test/project/lib/filter/doctrine/dmCorePlugin/base/BaseDmPageFormFilter.class.php
+++ b/dmCorePlugin/test/project/lib/filter/doctrine/dmCorePlugin/base/BaseDmPageFormFilter.class.php
@@ -90,6 +90,7 @@ abstract class BaseDmPageFormFilter extends BaseFormFilterDoctrine
       'is_active'    => 'Boolean',
       'is_secure'    => 'Boolean',
       'is_indexable' => 'Boolean',
+      'is_ssl'       => 'Boolean',
       'lang'         => 'Text',
     );
   }

--- a/dmCorePlugin/test/project/lib/filter/doctrine/dmCorePlugin/base/BaseDmPageTranslationFormFilter.class.php
+++ b/dmCorePlugin/test/project/lib/filter/doctrine/dmCorePlugin/base/BaseDmPageTranslationFormFilter.class.php
@@ -54,6 +54,10 @@ abstract class BaseDmPageTranslationFormFilter extends BaseFormFilterDoctrine
 			$this->setWidget('is_indexable', new sfWidgetFormChoice(array('choices' => array('' => $this->getI18n()->__('yes or no', array(), 'dm'), 1 => $this->getI18n()->__('yes', array(), 'dm'), 0 => $this->getI18n()->__('no', array(), 'dm')))));
 			$this->setValidator('is_indexable', new sfValidatorBoolean());
 		}
+		if($this->needsWidget('is_ssl')){
+			$this->setWidget('is_ssl', new sfWidgetFormChoice(array('choices' => array('' => $this->getI18n()->__('yes or no', array(), 'dm'), 1 => $this->getI18n()->__('yes', array(), 'dm'), 0 => $this->getI18n()->__('no', array(), 'dm')))));
+			$this->setValidator('is_ssl', new sfValidatorBoolean());
+		}
 		if($this->needsWidget('lang')){
 			$this->setWidget('lang', new sfWidgetFormDmFilterInput());
 			$this->setValidator('lang', new sfValidatorDoctrineChoice(array('required' => false, 'model' => 'DmPageTranslation', 'column' => 'lang')));
@@ -96,6 +100,7 @@ abstract class BaseDmPageTranslationFormFilter extends BaseFormFilterDoctrine
       'is_active'    => 'Boolean',
       'is_secure'    => 'Boolean',
       'is_indexable' => 'Boolean',
+      'is_ssl'       => 'Boolean',
       'lang'         => 'Text',
     );
   }

--- a/dmCorePlugin/test/project/lib/form/doctrine/dmCorePlugin/base/BaseDmPageTranslationForm.class.php
+++ b/dmCorePlugin/test/project/lib/form/doctrine/dmCorePlugin/base/BaseDmPageTranslationForm.class.php
@@ -68,6 +68,11 @@ abstract class BaseDmPageTranslationForm extends BaseFormDoctrine
 			$this->setValidator('is_indexable', new sfValidatorBoolean(array('required' => false)));
 		}
 		//column
+		if($this->needsWidget('is_ssl')){
+			$this->setWidget('is_ssl', new sfWidgetFormInputCheckbox());
+			$this->setValidator('is_ssl', new sfValidatorBoolean(array('required' => false)));
+		}
+		//column
 		if($this->needsWidget('lang')){
 			$this->setWidget('lang', new sfWidgetFormInputHidden());
 			$this->setValidator('lang', new sfValidatorChoice(array('choices' => array($this->getObject()->get('lang')), 'empty_value' => $this->getObject()->get('lang'), 'required' => false)));

--- a/dmCorePlugin/test/project/lib/model/doctrine/dmCorePlugin/base/BaseDmPage.class.php
+++ b/dmCorePlugin/test/project/lib/model/doctrine/dmCorePlugin/base/BaseDmPage.class.php
@@ -131,6 +131,11 @@ abstract class BaseDmPage extends myDoctrineRecord
              'notnull' => true,
              'default' => true,
              ));
+        $this->hasColumn('is_ssl', 'boolean', null, array(
+             'type' => 'boolean',
+             'notnull' => true,
+             'default' => false,
+             ));
 
 
         $this->index('recordModuleAction', array(
@@ -161,6 +166,7 @@ abstract class BaseDmPage extends myDoctrineRecord
               7 => 'is_active',
               8 => 'is_secure',
               9 => 'is_indexable',
+              10 => 'is_ssl',
              ),
              'length' => 7,
              ));

--- a/dmFrontPlugin/modules/dmFront/lib/BasedmFrontActions.class.php
+++ b/dmFrontPlugin/modules/dmFront/lib/BasedmFrontActions.class.php
@@ -57,6 +57,21 @@ class BasedmFrontActions extends dmFrontBaseActions
 
 	protected function secure()
 	{
+		$request = $this->getRequest();
+
+		if ($this->page->get('is_ssl') && !$request->isSecure())
+		{
+			// page should be secured via HTTPS -> redirect from HTTP
+			$url = preg_replace('/^http/', 'https', $request->getUri());
+			$this->redirect($url, 301);
+		}
+		else if (!$this->page->get('is_ssl') && $request->isSecure())
+		{
+			// page should only be accessed via HTTP -> redirect from HTTPS
+			$url = preg_replace('/^https/', 'http', $request->getUri());
+			$this->redirect($url, 301);
+		}
+
 		$user = $this->getUser();
 
 		$accessDenied =
@@ -83,7 +98,7 @@ class BasedmFrontActions extends dmFrontBaseActions
 			}
 
 			// use main/signin page
-			$this->getRequest()->setParameter('dm_page', dmDb::table('DmPage')->fetchSignin());
+			$request->setParameter('dm_page', dmDb::table('DmPage')->fetchSignin());
 
 			$this->getResponse()->setStatusCode($user->isAuthenticated() ? 403 : 401);
 

--- a/dmFrontPlugin/modules/dmPage/lib/DmPageFrontEditForm.php
+++ b/dmFrontPlugin/modules/dmPage/lib/DmPageFrontEditForm.php
@@ -9,7 +9,7 @@ class DmPageFrontEditForm extends DmPageForm
   {
     parent::configure();
     
-    $this->useFields(array('id', 'module', 'action', 'slug', 'name', 'title', 'h1', 'description', 'keywords', 'is_active', 'is_secure', 'credentials', 'is_indexable'), false);
+    $this->useFields(array('id', 'module', 'action', 'slug', 'name', 'title', 'h1', 'description', 'keywords', 'is_active', 'is_secure', 'credentials', 'is_indexable', 'is_ssl'), false);
     
     if(!sfConfig::get('dm_seo_use_keywords'))
     {
@@ -53,6 +53,7 @@ class DmPageFrontEditForm extends DmPageForm
     $this->widgetSchema['is_active']->setLabel('Available');
     $this->widgetSchema['is_secure']->setLabel('Requires authentication');
     $this->widgetSchema['is_indexable']->setLabel('Search engine crawlers');
+    $this->widgetSchema['is_ssl']->setLabel('Use HTTPS');
     
     if ($this->object->getNode()->isRoot())
     {
@@ -78,6 +79,7 @@ class DmPageFrontEditForm extends DmPageForm
       'is_secure' => $this->object->get('is_secure'),
       'credentials' => $this->object->get('credentials'),
       'is_indexable' => $this->object->get('is_indexable'),
+      'is_ssl' => $this->object->get('is_ssl'),
       'parent_id' => $this->object->getNodeParentId()
     ));
   }

--- a/dmFrontPlugin/modules/dmPage/templates/_edit.php
+++ b/dmFrontPlugin/modules/dmPage/templates/_edit.php
@@ -53,7 +53,8 @@ echo _tag('div.dm.dm_page_edit_wrap',
         _tag('li.dm_form_element.credentials.clearfix'.($page->isSecure ? '' : '.none'),
           $form['credentials']->label()->field()->error()
         ).
-        $form['is_indexable']->renderRow()
+        $form['is_indexable']->renderRow().
+        $form['is_ssl']->renderRow()
       )
     )
   ).


### PR DESCRIPTION
On the frontend where the admin wants to secure specific pages via HTTPS, one can now check "Use HTTPS" in "Edit Page" -> "Publication". Whenever a user visits this site, he will be redirected to the HTTPS version via HTTP status code 301. All other pages (use https not checked) will be redirected to HTTP if called via HTTPS.
