### PR TITLE
Web cache directory permissions not properly set by the task 'dm:permissions'

### DIFF
--- a/dmCorePlugin/lib/task/dmProjectPermissionsTask.class.php
+++ b/dmCorePlugin/lib/task/dmProjectPermissionsTask.class.php
@@ -51,7 +51,8 @@ EOF;
     $dirs = array(
       sfConfig::get('sf_apps_dir'),
       sfConfig::get('sf_lib_dir'),
-      sfConfig::get('sf_data_dir')
+      sfConfig::get('sf_data_dir'),
+      dmOs::join(sfConfig::get('sf_web_dir'), 'cache')
     );
 
     $dirFinder = sfFinder::type('dir');


### PR DESCRIPTION
One line was added to take in account the permission setting of the web cache directory when the task 'dm:permissions' is executed
